### PR TITLE
Fix asyn and StreamDevice dependencies

### DIFF
--- a/StreamDevice/install.sh
+++ b/StreamDevice/install.sh
@@ -48,6 +48,9 @@ else
     # prce developer library
     ibek support apt-install libpcre3-dev
 
+    # declare packages for installation in the Dockerfile's runtime stage
+    ibek support add-runtime-packages libpcre3
+
     # declare location of the pcre system library
     ibek support add-config-macro ${NAME} PCRE_LIB /usr/lib/x86_64-linux-gnu
 fi

--- a/asyn/install.sh
+++ b/asyn/install.sh
@@ -16,8 +16,11 @@ set -xe
 ibek support add-release-macro SNCSEQ --no-replace
 
 # installing for arm
-ibek support apt-install \
-    libtirpc-dev
+ibek support apt-install libtirpc-dev
+
+# declare packages for installation in the Dockerfile's runtime stage
+ibek support add-runtime-packages libtirpc-dev
+
 
 # get the source and fix up the configure/RELEASE files
 ibek support git-clone ${NAME} ${VERSION}
@@ -43,5 +46,3 @@ ibek support compile ${NAME}
 
 # prepare *.bob, *.pvi, *.ibek.support.yaml for access outside the container.
 ibek support generate-links ${FOLDER}
-
-


### PR DESCRIPTION
These were broken during the move to Ubuntu 24