### PR TITLE
Fixed NDCircularBuffConfigure

### DIFF
--- a/ADCore/ADCore.ibek.support.yaml
+++ b/ADCore/ADCore.ibek.support.yaml
@@ -1333,10 +1333,16 @@ entity_models:
           Max buffer size in number of frames
         default: 128
 
+      MAX_MEMORY:
+        type: int
+        description: |-
+          Max memory size in bytes
+        default: 1048576
+
     pre_init:
       - value: |
-          # NDCircularBuffConfigure(portName, queueSize, blockingCallbacks,
-          NDCircularBuffConfigure(
+          # NDCircularBuffConfigure(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxBuffers, maxMemory)
+          NDCircularBuffConfigure("{{PORT}}", {{QUEUE}}, {{BLOCK}}, "{{NDARRAY_PORT}}", {{NDARRAY_ADDR}}, {{MAX_BUFFERS}}, {{MAX_MEMORY}})
 
     databases:
       - file: $(ADCORE)/db/NDCircularBuff.template


### PR DESCRIPTION
Closes #92 

Tested briefly with ADSimDetector. Have not verified the full functionality though.

I built a new image with this PR in https://github.com/epics-containers/ioc-adsimdetector and ran the image using https://github.com/bluesky/epics-services-for-ophyd/pull/6

Then I used an Ophyd device to do a software trigger on the buffer with the simulated camera and the plugin: https://github.com/bluesky/ophyd/pull/1240