### PR TITLE
switch to single calc dbd that includes all the others (calcSupport.dbd)

### DIFF
--- a/calc/calc.install.yml
+++ b/calc/calc.install.yml
@@ -3,13 +3,7 @@
 module: calc
 version: R3-7-5
 dbds:
-  - aCalcoutRecord.dbd
-  - calc.dbd
   - calcSupport.dbd
-  - sCalcoutRecord.dbd
-  - transformRecord.dbd
-  - swaitRecord.dbd
-  - sseqRecord.dbd
 libs:
   - calc
 
@@ -19,5 +13,6 @@ patch_lines:
     line: DIRS += configure calcApp
 
 remove_macros:
+  # if these have not been compiled then we need them blanked out
   - SNCSEQ
   - SSCAN


### PR DESCRIPTION
calcSupport.dbd includes the other dbds dynamically.

This avoids issues with sequencer and sscan dependencies creating/not creating additional dbd files.