### PR TITLE
Fix pmac support yaml issues

### DIFF
--- a/pmac/make_pvi.sh
+++ b/pmac/make_pvi.sh
@@ -1,19 +1,25 @@
 # a record of how the pvi.device.yaml files were generated
 
 pvi convert device /workspaces/ioc-pmac/ibek-support/pmac  \
-    /epics/support/pmac/pmacApp/src/pmacAxis.h \
+    --name pmacAxis \
     --template /epics/support/motor/db/basic_asyn_motor.db \
     --template /epics/support/pmac/db/dls_pmac_asyn_motor.template \
     --template /epics/support/pmac/db/eloss_kill_autohome_records.template
 
 pvi convert device /workspaces/ioc-pmac/ibek-support/pmac  \
-    /epics/support/pmac/pmacApp/src/pmacController.h \
-    --template /epics/support/pmac/db/pmacController.template
+    --name pmacController \
+    --template /epics/support/pmac/db/pmacController.template \
+    --template /epics/support/pmac/db/pmacStatus.template
 
 pvi convert device /workspaces/ioc-pmac/ibek-support/pmac  \
-    /epics/support/pmac/pmacApp/src/pmacTrajectory.h \
+    --name ppmacController \
+    --template /epics/support/pmac/db/pmacController.template \
+    --template /epics/support/pmac/db/powerPmacStatus.template
+
+pvi convert device /workspaces/ioc-pmac/ibek-support/pmac  \
+    --name pmacTrajectory \
     --template /epics/support/pmac/db/pmacControllerTrajectory.template
 
 pvi convert device /workspaces/ioc-pmac/ibek-support/pmac  \
-    /epics/support/pmac/pmacApp/src/pmacCSController.h \
+    --name pmacCSController \
     --template /epics/support/pmac/db/pmacCsController.template

--- a/pmac/pmac.ibek.support.yaml
+++ b/pmac/pmac.ibek.support.yaml
@@ -355,19 +355,16 @@ entity_models:
           # Configure Model 3 Axes Driver (Controler Port, Axis Count)
           pmacCreateAxes("{{name}}", {{NAxes}})
 
-    # TODO - these are needed to create description in the axis status screen
-    # BUT this is creating a load of repeated AXIS0: records
-    # TODO debug this.
-
-    # sub_entities:
-    #   - type: ibek.repeat
-    #     variable: axis
-    #     values: "{{ range(1, NAxes + 1) }}"
-    #     entity:
-    #       type: pmac._axisStatus
-    #       PMAC: "{{ P }}"
-    #       PORT: "{{ name }}"
-    #       AXIS: "{{ axis | int }}"
+    # these are needed to create individual axis status PVs
+    sub_entities:
+      - type: ibek.repeat
+        variable: axis
+        values: "{{ range(1, NAxes + 1) | list }}"
+        entity:
+          type: pmac._axisStatus
+          PMAC: "{{ P }}"
+          PORT: "{{ name }}"
+          AXIS: "{{ axis | int }}"
 
     databases:
       - file: powerPmacStatus.template

--- a/pmac/pmac.ibek.support.yaml
+++ b/pmac/pmac.ibek.support.yaml
@@ -3,6 +3,29 @@
 module: pmac
 
 entity_models:
+  - name: _axisStatus
+    description: adds a single axis status set of PVs to a controller
+    parameters:
+      PMAC:
+        type: str
+        description: |-
+          PV Prefix from the contoller
+
+      PORT:
+        type: object
+        description: |-
+          Delta tau motor controller asyn port
+
+      AXIS:
+        type: int
+        description: |-
+          Axis number on controller
+
+    databases:
+      - file: pmacStatusAxis.template
+        args:
+          .*:
+
   - name: pmacAsynIPPort
     description: |-
       This will create an AsynPort connecting to a PMAC or GeoBrick over IP
@@ -157,9 +180,9 @@ entity_models:
 
     pvi:
       yaml_path: pmacController.pvi.device.yaml
-      pv_prefix: "{{ P }}"
       ui_macros:
         P:
+
   - name: pmacAsynSSHPort
     description: |-
       This will create an AsynPort connecting to a PowerPMAC over SSH
@@ -271,18 +294,6 @@ entity_models:
           feedrate below which we go into error
         default: 100
 
-      PMAC:
-        type: str
-        description: |-
-          Pmac/Geobrick name
-        default: ""
-
-      AXIS:
-        type: str
-        description: |-
-          Axis number
-        default: ""
-
       PORT:
         type: str
         description: |-
@@ -344,13 +355,21 @@ entity_models:
           # Configure Model 3 Axes Driver (Controler Port, Axis Count)
           pmacCreateAxes("{{name}}", {{NAxes}})
 
-    databases:
-      - file: pmacStatusAxis.template
-        args:
-          AXIS:
-          PORT:
-          PMAC:
+    # TODO - these are needed to create description in the axis status screen
+    # BUT this is creating a load of repeated AXIS0: records
+    # TODO debug this.
 
+    # sub_entities:
+    #   - type: ibek.repeat
+    #     variable: axis
+    #     values: "{{ range(1, NAxes + 1) }}"
+    #     entity:
+    #       type: pmac._axisStatus
+    #       PMAC: "{{ P }}"
+    #       PORT: "{{ name }}"
+    #       AXIS: "{{ axis | int }}"
+
+    databases:
       - file: powerPmacStatus.template
         args:
           P:
@@ -371,6 +390,11 @@ entity_models:
           TIMEOUT:
           NAXES:
           PORT:
+
+    pvi:
+      yaml_path: ppmacController.pvi.device.yaml
+      ui_macros:
+        P:
 
   - name: CS
     description: |-
@@ -482,11 +506,10 @@ entity_models:
           PMAC: "{{PmacController.P}}"
           NAxes: "{{PmacController.NAXES}}"
 
-    # pvi:
-    #   yaml_path: pmacTrajectory.pvi.device.yaml
-    #   pv_prefix: "{{ PmacController.P }}"
-    #   ui_macros:
-    #     PMAC:
+    pvi:
+      yaml_path: pmacTrajectory.pvi.device.yaml
+      ui_macros:
+        PMAC: "{{ PmacController.P }}"
 
   - name: dls_pmac_asyn_motor
     description: |-
@@ -804,7 +827,7 @@ entity_models:
           P:
           M:
           PORT: "{{ Controller }}"
-          SPORT: "{{ '' if is_cs else Controller.pmacAsynPort }}"
+          SPORT: "{{ '' if is_cs else Controller.pmacAsynPort | default(Controller.pmacAsynSSHPort) }}"
           CS: "{{Controller.CS if is_cs else 0}}"
           PMAC: "{{ Controller.PmacController.P if is_cs else Controller.P }}"
           VELO:

--- a/pmac/ppmacController.pvi.device.yaml
+++ b/pmac/ppmacController.pvi.device.yaml
@@ -1,4 +1,4 @@
-label: pmacController
+label: ppmacController
 children:
   - type: Group
     name: PmacController
@@ -332,61 +332,19 @@ children:
           type: TextRead
 
   - type: Group
-    name: PmacStatus
+    name: PowerPmacStatus
     layout:
       type: Grid
       labelled: true
     children:
       - type: SignalR
-        name: I10
-        read_pv: $(P):I10
+        name: SERVOPERIOD
+        read_pv: $(P):SERVO_PERIOD
         read_widget:
           type: TextRead
 
       - type: SignalR
-        name: IOHANDSHAKE
-        read_pv: $(P):IO_HANDSHAKE
-        read_widget:
-          type: TextRead
-
-      - type: SignalR
-        name: PLCCONTROL
-        read_pv: $(P):PLC_CONTROL
-        read_widget:
-          type: TextRead
-
-      - type: SignalR
-        name: ERRREPMODE
-        read_pv: $(P):ERRREPMODE
-        read_widget:
-          type: TextRead
-
-      - type: SignalR
-        name: DPRAMCOMMSINT
-        read_pv: $(P):DPRAM_COMMS_INT
-        read_widget:
-          type: LED
-
-      - type: SignalR
-        name: DPRAMCOMMS
-        read_pv: $(P):DPRAM_COMMS
-        read_widget:
-          type: LED
-
-      - type: SignalR
-        name: VMEADDRMODE
-        read_pv: $(P):VME_ADDR_MODE
-        read_widget:
-          type: TextRead
-
-      - type: SignalR
-        name: VMEDPRAMBASE
-        read_pv: $(P):VME_DPRAMBASE
-        read_widget:
-          type: TextRead
-
-      - type: SignalR
-        name: VMEINTLVL
-        read_pv: $(P):VME_INTLVL
+        name: READECHO
+        read_pv: $(P):READ_ECHO
         read_widget:
           type: TextRead


### PR DESCRIPTION
- ppmac fails on rendering SPORT
- pmacStatusAxis.template instantiated incorrectly in ppmac 
- TODO: still need to do pmacStatusAxis.template for geobrick!
- no pvi entry for Trajectory scan
- now have separate pvi entries for Geobrick and PPmac as they have different status PVs