### PR TITLE
Add XMLSIZE parameter to NDROIStat

### DIFF
--- a/ADCore/ADCore.ibek.support.yaml
+++ b/ADCore/ADCore.ibek.support.yaml
@@ -2805,6 +2805,12 @@ entity_models:
           Maximum number threads
         default: 1
 
+      XMLSIZE:
+        type: int
+        description: |-
+          Number of elements of the ND attributes xml waveform record
+        default: 1024
+
     pre_init:
       - value: |
           # NDROIStatConfigure(portName, queueSize, blockingCallbacks,
@@ -2835,6 +2841,7 @@ entity_models:
           R:
           TIMEOUT:
           SCANRATE:
+          XMLSIZE:
 
     pvi:
       yaml_path: NDROIStat.pvi.device.yaml


### PR DESCRIPTION
I think this is supposed to be an `int` so I was confused why the existing XMLSIZE in the hdf5 plugin uses `str`

https://epics-base.github.io/epics-base/waveformRecord.html

This just adds XMLSIZE to NDROIStat for now, pending #131