### PR TITLE
Update pmac module to release 2-7-9

### DIFF
--- a/pmac/pmac.install.yml
+++ b/pmac/pmac.install.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../_scripts/support_install_variables.json
 
 module: pmac
-version: 2-7-8
+version: 2-7-9
 
 dbds:
   - pmacAsynIPPort.dbd


### PR DESCRIPTION
Pull request for fixing CsAxis_RBV read, use USHM in trajectory scan motion program and add error message for scale_==0 in `pmacCSAxis::move` .