### PR TITLE
Add network interface entity

### DIFF
--- a/ADAravis/ADAravis.ibek.support.yaml
+++ b/ADAravis/ADAravis.ibek.support.yaml
@@ -3,6 +3,19 @@
 module: ADAravis
 
 entity_models:
+  - name: interfaceName
+    description: |-
+      Limit connection discovery to a specific network interface
+    parameters:
+      name:
+        type: str
+        description: |-
+          Name of the network interface to use for camera discovery (e.g. em1, p2p1, ...)
+    pre_init:
+      - value: |
+          # aravisInterfaceName(const char *interfaceName)
+          aravisInterfaceName("{{name}}")
+
   - name: aravisCamera
     description: |-
       Creates an aravisCamera camera areaDetector driver


### PR DESCRIPTION
This PR adds an `interfaceName` entity to limit networks interfaces used when developing in devcontainer.