### PR TITLE
Change motorpositioner.motor's type to str

### DIFF
--- a/positioner/positioner.ibek.support.yaml
+++ b/positioner/positioner.ibek.support.yaml
@@ -123,8 +123,7 @@ entity_models:
           .*:
           P: "{{MP.P}}"
           MP: "{{MP.MP}}"
-          EGU: "{{motor.EGU}}"
-          motor: "{{motor.M | default(motor.Q) }}"
+          motor: "{{motor}}"
 
   - name: multipositioner
     description: |-


### PR DESCRIPTION
Change motorpositioner.motor's type from object to str.
Related change in database to remove reference to motor's atttributes because motor is no longer an object.