### PR TITLE
Remove name field for positioner and motorpositioner

### DIFF
--- a/positioner/positioner.ibek.support.yaml
+++ b/positioner/positioner.ibek.support.yaml
@@ -112,10 +112,6 @@ entity_models:
         description: |-
           Positioner value for position 16
         default: 0
-      name:
-        type: str
-        description: |-
-          Name of the positioner
 
     databases:
       - file: $(POSITIONER)/db/motorpositioner.template
@@ -389,10 +385,6 @@ entity_models:
         description: |-
           Positioner value for position 16
         default: 0
-      name:
-        type: str
-        description: |-
-          Name of the positioner
 
     databases:
       - file: $(POSITIONER)/db/positioner.template


### PR DESCRIPTION
Removed name field for positioner and motorpositioner. Not done for multipositioner because its name field is used for referencingfrom motorpositioner. 
If the EGU field is not used, we will need to drop it too. I've asked Giles and Tom and I'm waiting for their replies.