### PR TITLE
Auto templates for mks937x, ether_ip additions, and iocStats/digitelMpc cleanup

### DIFF
--- a/digitelMpc/digitelMpc.ibek.support.yaml
+++ b/digitelMpc/digitelMpc.ibek.support.yaml
@@ -3,13 +3,13 @@
 module: digitelMpc
 
 entity_models:
-  - name: digitelMpcqT
+  - name: digitelMpcqTsp
     description: |-
       Template database for digitel MPCq - Titanium Sublimation Pump
       Pete Owens - January 2020
     parameters:
       device:
-        type: str
+        type: id
         description: |-
           device name
 
@@ -57,14 +57,9 @@ entity_models:
           "24":
           "01":
       ctlsrc:
-        type: str
+        type: int
         description: |-
           control source (0 = service, 1 = Ion Pump 1, 2 = Ion Pump 2)
-
-      name:
-        type: id
-        description: |-
-          Object name and gui association name
 
       protocol:
         type: str
@@ -133,8 +128,8 @@ entity_models:
           Protocol file to use
         default: digitelMpc.proto
         values:
-          '"digitelMpc.proto"':
-          '"digitelMpcq.proto"':
+          digitelMpc.proto:
+          digitelMpcq.proto:
     databases:
       - file: $(DIGITELMPC)/db/digitelMpc.template
         args: { device: null, port: null, unit: null, proto: null }
@@ -222,7 +217,7 @@ entity_models:
 
     databases:
       - file: $(DIGITELMPC)/db/digitelMpcIonp.template
-        args: { device: null, port: "{{MPC.port}}", unit: "{{MPC.unit}}", pump: null, size: null, sp1on: null, sp1off: null, sp2on: null, sp2off: null, alh: null, text: null, proto: null, disptext: null }
+        args: { device: null, port: "{{MPC.port}}", unit: "{{MPC.unit}}", pump: null, size: null, sp1on: null, sp1off: null, sp2on: null, sp2off: null, alh: null, text: null, proto: "{{MPC.proto}}", disptext: null }
 
   - name: digitelMpcTspGroup
     description: |-

--- a/ether_ip/ether_ip.ibek.support.yaml
+++ b/ether_ip/ether_ip.ibek.support.yaml
@@ -70,7 +70,7 @@ entity_models:
       - value: |
           drvEtherIP_define_PLC("{{port}}", "{{ip}}", 0)
     databases:
-      - file: $(ETHER_IP)/db/ether_ip_plcInfo.template
+      - file: ether_ip_plcInfo.template
         args:
           port:
           device:

--- a/ether_ip/ether_ip.install.yml
+++ b/ether_ip/ether_ip.install.yml
@@ -9,3 +9,9 @@ dbds:
 
 libs:
   - ether_ip
+
+bash:
+  # ether_ip_plcInfo.template is a DLS addition not yet in upstream ether_ip;
+  # copy it into the module's db/ so msi finds it via EPICS_DB_INCLUDE_PATH.
+  - cmd: cp {{ ibek_support_folder }}/ether_ip_plcInfo.template db/
+    post_build: true

--- a/ether_ip/ether_ip_plcInfo.template
+++ b/ether_ip/ether_ip_plcInfo.template
@@ -1,0 +1,45 @@
+# File ether_ip_plcInfo.template
+#
+# % macro, __doc__, Template for status details of PLC using ether_ip module.
+#
+# % macro, device,       Mandatory.  Device PV prefix.
+# % macro, port,         Mandatory.  EtherIP port name.
+#
+# % macro, healthy_ZNAM, Optional.   Defaults to NotHealthy.   String to display when healthy bit is not set (ZNAM field on PLCHEALTHY bi record).  Max 19 characters.
+# % macro, healthy_ZSV,  Optional.   Defaults to MAJOR.        Alarm status when healthy bit is not set (ZSV field on PLCHEALTHY bi record).  Must be one of the EPICS alarm severity names.
+# % macro, healthy_ONAM, Optional.   Defaults to Healthy.      String to display when healthy bit is set (ONAM field on PLCHEALTHY bi record).  Max 19 characters.
+# % macro, healthy_OSV,  Optional.   Defaults to NO_ALARM.     Alarm status when healthy bit is set (OSV field on PLCHEALTHY bi record).  Must be one of the EPICS alarm severity names.
+#
+# This associates BOY screens with the template.
+# % gui, $(name=), boydetail, ether_ipApp_opi/plcInfo_embed.opi, device=$(device)
+# % gui, $(name=), boyembed, ether_ipApp_opi/plcInfo_embed_box.opi, name=$(port), device=$(device)
+# % gui, $(name=), boyembed, ether_ipApp_opi/plcInfo_embed.opi, name=$(port), device=$(device)
+#
+# This associates EDM screens with the template.
+# % gui, $(name=), edm, ether_ip_plcInfo.edl, device=$(device)
+# % gui, $(name=), edmembed, ether_ip_plcInfo-embed.edl, device=$(device)
+#
+record(stringin, "$(device):PLCNAME") {
+    field(DESC, "Read PLC Name")
+    field(SCAN, "10 second")
+    field(DTYP, "EtherIP")
+    field(INP, "@$(port) PLC_Name")
+}
+
+record(stringin, "$(device):PLCSTATUS") {
+    field(DESC, "Read PLC Status")
+    field(SCAN, "10 second")
+    field(DTYP, "EtherIP")
+    field(INP, "@$(port) PLC_Status")
+}
+
+record(bi, "$(device):PLCHEALTHY") {
+    field(DESC, "Read PLC Healthy Flag")
+    field(SCAN, "2 second")
+    field(DTYP, "EtherIP")
+    field(INP, "@$(port) PLC_Healthy_Flag")
+    field(ZNAM, "$(healthy_ZNAM=NotHealthy)")
+    field(ZSV, "$(healthy_ZSV=MAJOR)")
+    field(ONAM, "$(healthy_ONAM=Healthy)")
+    field(OSV, "$(healthy_OSV=NO_ALARM)")
+}

--- a/iocStats/iocStats.ibek.support.yaml
+++ b/iocStats/iocStats.ibek.support.yaml
@@ -3,62 +3,6 @@
 module: devIocStats
 
 entity_models:
-  - name: devIocStatsHelper
-    description: |-
-      TODO:ADD DESCRIPTION
-    parameters:
-      ioc:
-        type: str
-        description: |-
-          ioc name
-
-      name:
-        type: id
-        description: |-
-          gui element name
-
-      scanMonitor:
-        type: bool
-        description: |-
-          choice to include scan monitor
-        default: true
-
-      guiTags:
-        type: bool
-        description: |-
-          choice to include gui tags
-        default: true
-
-      screen:
-        type: str
-        description: |-
-          edm file for gui tags
-        default: ioc_stats_softdls.edl
-
-      EDM_FILE:
-        type: str
-        description: |-
-          edm screen, defaults to ioc_stats_softdls.edl
-        default: ioc_stats_softdls.edl
-
-      IOC:
-        type: str
-        description: |-
-          ioc name
-
-    databases:
-      - file: $(IOCSTATS)/db/iocGui.db
-        args:
-          IOC:
-          name:
-          EDM_FILE:
-      - file: $(IOCSTATS)/db/iocAdminSoft.db
-        args:
-          IOC:
-      - file: $(IOCSTATS)/db/iocAdminScanMon.db
-        args:
-          IOC:
-
   - name: iocAdminVxWorks
     description: |-
       Create some records for reading IOC statistics and details.
@@ -86,34 +30,6 @@ entity_models:
       - file: $(IOCSTATS)/db/iocAdminScanMon.db
         args:
           IOC:
-
-  - name: iocGui
-    description: |-
-      TODO:ADD DESCRIPTION
-    parameters:
-      name:
-        type: id
-        description: |-
-          name for gui elements
-        default: None
-
-      EDM_FILE:
-        type: str
-        description: |-
-          edm screen, defaults to ioc_stats_softdls.edl
-        default: ioc_stats_softdls.edl
-
-      IOC:
-        type: str
-        description: |-
-          ioc name
-
-    databases:
-      - file: $(IOCSTATS)/db/iocGui.db
-        args:
-          IOC:
-          name:
-          EDM_FILE:
 
   - name: iocAdminSoft
     description: |-

--- a/mks937a/mks937a.ibek.support.yaml
+++ b/mks937a/mks937a.ibek.support.yaml
@@ -92,7 +92,22 @@ entity_models:
 
     databases:
       - file: $(MKS937A)/db/mks937aImgMean.template
-        args: { device: null, current: null, nimgs: null, img1: null, img2: null, img3: null, img4: null, img5: null, img6: null, img7: null, img8: null, img9: null, img10: null }
+        args:
+          {
+            device: null,
+            current: null,
+            nimgs: null,
+            img1: null,
+            img2: null,
+            img3: null,
+            img4: null,
+            img5: null,
+            img6: null,
+            img7: null,
+            img8: null,
+            img9: null,
+            img10: null,
+          }
 
   - name: mks937aImgGroup
     description: |-
@@ -265,7 +280,7 @@ entity_models:
         type: float
         description: |-
           (limits min value of protection setpoint)
-        default: 1.3e-05
+        default: 1.3e-5
 
       prosp_hopr:
         type: float
@@ -277,7 +292,7 @@ entity_models:
         type: float
         description: |-
           (low operator value - helps display set correct range).
-        default: 1.3e-05
+        default: 1.3e-5
 
       prosp_hihi:
         type: float
@@ -289,7 +304,7 @@ entity_models:
         type: float
         description: |-
           The LOLO alarm field on the protection setpoint record.
-        default: 1.2e-05
+        default: 1.2e-5
 
       prosp_high:
         type: float
@@ -313,7 +328,7 @@ entity_models:
         type: float
         description: |-
           The desired relay setpoint value.
-        default: 1e-06
+        default: 1e-6
 
       rlysp_drvh:
         type: float
@@ -355,13 +370,13 @@ entity_models:
         type: float
         description: |-
           The HIGH alarm field on the relay setpoint record.
-        default: 1.1e-06
+        default: 1.1e-6
 
       rlysp_low:
         type: float
         description: |-
           The LOW alarm field on the relay setpoint record.
-        default: 9e-07
+        default: 9e-7
 
       rlysp_desc:
         type: str
@@ -409,13 +424,13 @@ entity_models:
         type: float
         description: |-
           The HIGH alarm field on the second relay setpoint record.
-        default: 1.1e-07
+        default: 1.1e-7
 
       rlasp_low:
         type: float
         description: |-
           The LOW alarm field on the second relay setpoint record.
-        default: 9e-08
+        default: 9e-8
 
       rlasp_desc:
         type: str
@@ -437,7 +452,53 @@ entity_models:
 
     databases:
       - file: $(MKS937A)/db/mks937aImg.template
-        args: { device: null, port: "{{GCTLR.port}}", channel: null, ctlsp_level: null, ctlsp_drvh: null, ctlsp_drvl: null, ctlsp_hopr: null, ctlsp_lopr: null, ctlsp_hihi: null, ctlsp_lolo: null, ctlsp_high: null, ctlsp_low: null, ctlsp_desc: null, prosp_level: null, prosp_drvh: null, prosp_drvl: null, prosp_hopr: null, prosp_lopr: null, prosp_hihi: null, prosp_lolo: null, prosp_high: null, prosp_low: null, prosp_desc: null, rlysp_level: null, rlysp_drvh: null, rlysp_drvl: null, rlysp_hopr: null, rlysp_lopr: null, rlysp_hihi: null, rlysp_lolo: null, rlysp_high: null, rlysp_low: null, rlysp_desc: null, rlasp_drvh: null, rlasp_drvl: null, rlasp_hopr: null, rlasp_lopr: null, rlasp_hihi: null, rlasp_lolo: null, rlasp_high: null, rlasp_low: null, rlasp_desc: null, offwarn: null, ilk_write_access_pv: null }
+        args:
+          {
+            device: null,
+            port: "{{GCTLR.port}}",
+            channel: null,
+            ctlsp_level: null,
+            ctlsp_drvh: null,
+            ctlsp_drvl: null,
+            ctlsp_hopr: null,
+            ctlsp_lopr: null,
+            ctlsp_hihi: null,
+            ctlsp_lolo: null,
+            ctlsp_high: null,
+            ctlsp_low: null,
+            ctlsp_desc: null,
+            prosp_level: null,
+            prosp_drvh: null,
+            prosp_drvl: null,
+            prosp_hopr: null,
+            prosp_lopr: null,
+            prosp_hihi: null,
+            prosp_lolo: null,
+            prosp_high: null,
+            prosp_low: null,
+            prosp_desc: null,
+            rlysp_level: null,
+            rlysp_drvh: null,
+            rlysp_drvl: null,
+            rlysp_hopr: null,
+            rlysp_lopr: null,
+            rlysp_hihi: null,
+            rlysp_lolo: null,
+            rlysp_high: null,
+            rlysp_low: null,
+            rlysp_desc: null,
+            rlasp_drvh: null,
+            rlasp_drvl: null,
+            rlasp_hopr: null,
+            rlasp_lopr: null,
+            rlasp_hihi: null,
+            rlasp_lolo: null,
+            rlasp_high: null,
+            rlasp_low: null,
+            rlasp_desc: null,
+            offwarn: null,
+            ilk_write_access_pv: null,
+          }
 
   - name: mks937aGaugeEGU
     description: |-
@@ -480,7 +541,7 @@ entity_models:
           s: ""
           name:
           aitype: Soft Channel
-          aiinp: "{{eguInputPV}}  CP"
+          aiinp: "{{eguInputPV}} CP"
 
       - file: $(MKS937A)/db/mks937aPlogEGU.template
         args:
@@ -559,7 +620,20 @@ entity_models:
 
     databases:
       - file: $(MKS937A)/db/mks937aGaugeGroup.template
-        args: { device: null, gauge1: null, gauge2: null, gauge3: null, gauge4: null, gauge5: null, gauge6: null, gauge7: null, gauge8: null, SELM: null, SELN: null }
+        args:
+          {
+            device: null,
+            gauge1: null,
+            gauge2: null,
+            gauge3: null,
+            gauge4: null,
+            gauge5: null,
+            gauge6: null,
+            gauge7: null,
+            gauge8: null,
+            SELM: null,
+            SELN: null,
+          }
 
   - name: mks937a
     description: |-
@@ -761,7 +835,23 @@ entity_models:
 
     databases:
       - file: $(MKS937A)/db/mks937aPirg.template
-        args: { device: null, port: "{{GCTLR.port}}", channel: null, rlysp_level: null, rlysp_drvh: null, rlysp_drvl: null, rlysp_hopr: null, rlysp_lopr: null, rlysp_hihi: null, rlysp_lolo: null, rlysp_high: null, rlysp_low: null, rlysp_desc: null, ilk_write_access_pv: null }
+        args:
+          {
+            device: null,
+            port: "{{GCTLR.port}}",
+            channel: null,
+            rlysp_level: null,
+            rlysp_drvh: null,
+            rlysp_drvl: null,
+            rlysp_hopr: null,
+            rlysp_lopr: null,
+            rlysp_hihi: null,
+            rlysp_lolo: null,
+            rlysp_high: null,
+            rlysp_low: null,
+            rlysp_desc: null,
+            ilk_write_access_pv: null,
+          }
 
   - name: mks937aPirgGroup
     description: |-
@@ -822,7 +912,18 @@ entity_models:
 
     databases:
       - file: $(MKS937A)/db/mks937aPirgGroup.template
-        args: { device: null, pirg1: null, pirg2: null, pirg3: null, pirg4: null, pirg5: null, pirg6: null, pirg7: null, pirg8: null }
+        args:
+          {
+            device: null,
+            pirg1: null,
+            pirg2: null,
+            pirg3: null,
+            pirg4: null,
+            pirg5: null,
+            pirg6: null,
+            pirg7: null,
+            pirg8: null,
+          }
 
   - name: mks937aGauge
     description: |-

--- a/mks937a/mks937a.ibek.support.yaml
+++ b/mks937a/mks937a.ibek.support.yaml
@@ -960,3 +960,24 @@ entity_models:
       - file: $(MKS937A)/db/mks937aInterlock.template
         args:
           .*:
+
+  - name: auto_mks937aPlogADC
+    description: |-
+      Template database to create virtual calibrated ADCs as inputs to :PLOG.
+      Originally targeting use case where EtherCAT ADCs provide a 0..32767 value
+      and to scale this to provide the originating voltage from the MKS controller.
+    parameters:
+      device:
+        type: str
+        description: |-
+          device name
+      plog_adc_pv:
+        type: str
+        description: |-
+          Raw value ADC PV name
+
+    databases:
+      - file: $(MKS937A)/db/mks937aPlogADC.template
+        args:
+          device:
+          plog_adc_pv:

--- a/mks937b/mks937b.ibek.support.yaml
+++ b/mks937b/mks937b.ibek.support.yaml
@@ -1173,3 +1173,90 @@ entity_models:
           offwarn:
           GCTLR:
           channel:
+
+  - name: mks937bImgMean
+    description: |-
+      Template database to calculate the mean pressure from a number of IMGs
+      Pete Owens - 26/6/06
+    parameters:
+      device:
+        type: str
+        description: |-
+          device name
+
+      current:
+        type: str
+        description: |-
+          beam current
+
+      nimgs:
+        type: int
+        description: |-
+          number of gauges
+
+      img1:
+        type: str
+        description: |-
+          img 1 device name
+
+      img2:
+        type: str
+        description: |-
+          img 2 device name
+
+      img3:
+        type: str
+        description: |-
+          img 3 device name
+
+      img4:
+        type: str
+        description: |-
+          img 4 device name
+
+      img5:
+        type: str
+        description: |-
+          img 5 device name
+
+      img6:
+        type: str
+        description: |-
+          img 6 device name
+
+      img7:
+        type: str
+        description: |-
+          img 7 device name
+
+      img8:
+        type: str
+        description: |-
+          img 8 device name
+
+      img9:
+        type: str
+        description: |-
+          img 9 device name
+
+      img10:
+        type: str
+        description: |-
+          img 10 device name
+
+    databases:
+      - file: $(MKS937B)/db/mks937bImgMean.template
+        args:
+          device:
+          current:
+          nimgs:
+          img1:
+          img2:
+          img3:
+          img4:
+          img5:
+          img6:
+          img7:
+          img8:
+          img9:
+          img10:

--- a/mks937b/mks937b.ibek.support.yaml
+++ b/mks937b/mks937b.ibek.support.yaml
@@ -603,6 +603,11 @@ entity_models:
     description: |-
       TODO:ADD DESCRIPTION
     parameters:
+      name:
+        type: id
+        description: |-
+          Device name, used as the gauge record name in mks937bGauge.template.
+
       dom:
         type: str
         description: |-


### PR DESCRIPTION
## Summary
- Add auto templates to mks937a / mks937b
- Auto fixes for digitelMpc and mks937b
- Include the DLS ether_ip template (+ plcInfo template)
- Drop iocStats entities that reference DLS-only iocGui.db
- Remove spurious space in mks937a

## Commits
- 6fdf5db remove spurious space in mks937a
- e4803c1 drop iocStats entities that reference DLS-only iocGui.db
- acf8c9d include the DLS ether_ip template
- dbd6838 auto fixes to digitelMpc and mks937b
- 1170b50 add auto templates to mks937x