### PR TITLE
mks937a/b: drop unused name parameter, clarify int descriptions

### DIFF
--- a/mks937a/mks937a.ibek.support.yaml
+++ b/mks937a/mks937a.ibek.support.yaml
@@ -504,11 +504,6 @@ entity_models:
     description: |-
       TODO:ADD DESCRIPTION
     parameters:
-      name:
-        type: id
-        description: |-
-          Device name
-
       dom:
         type: str
         description: |-
@@ -539,7 +534,6 @@ entity_models:
           id: "{{ '%02d' % id }}"
           c: ""
           s: ""
-          name:
           aitype: Soft Channel
           aiinp: "{{eguInputPV}} CP"
 

--- a/mks937a/mks937a.ibek.support.yaml
+++ b/mks937a/mks937a.ibek.support.yaml
@@ -512,7 +512,8 @@ entity_models:
       id:
         type: int
         description: |-
-          ID number as 2 digit string (e.g. 01)
+          Gauge ID number. Rendered zero-padded to 2 digits in PV
+          substitutions (e.g. 1 -> "01").
 
       input:
         type: str
@@ -940,7 +941,8 @@ entity_models:
       id:
         type: int
         description: |-
-          ID number as 2 digit string (e.g. 01)
+          Gauge ID number. Rendered zero-padded to 2 digits in PV
+          substitutions (e.g. 1 -> "01").
 
       c:
         type: int

--- a/mks937b/mks937b.ibek.support.yaml
+++ b/mks937b/mks937b.ibek.support.yaml
@@ -224,7 +224,8 @@ entity_models:
       id:
         type: int
         description: |-
-          ID number as 2 digit string (e.g. 01)
+          Gauge ID number. Rendered zero-padded to 2 digits in PV
+          substitutions (e.g. 1 -> "01").
 
       plog_adc_pv:
         type: str
@@ -337,7 +338,8 @@ entity_models:
       address:
         type: int
         description: |-
-          Controller address (001 .. 253)
+          Controller address (1..253). Rendered zero-padded to 3 digits
+          in PV substitutions (e.g. 1 -> "001").
 
     databases:
       - file: $(MKS937B)/db/mks937b.template
@@ -616,7 +618,8 @@ entity_models:
       id:
         type: int
         description: |-
-          ID number as 2 digit string (e.g. 01)
+          Gauge ID number. Rendered zero-padded to 2 digits in PV
+          substitutions (e.g. 1 -> "01").
 
       input:
         type: str


### PR DESCRIPTION
## Summary

### mks937aGaugeEGU: drop unused \`name\` parameter (3a15644)
- \`mks937aGaugeEGU\` is a leaf entity — nothing cross-references its \`name\`, so the \`name: type: id\` parameter shouldn't be there per the ibek convention (kept only when it's a real cross-reference).
- Also drop \`name:\` from the \`mks937aGauge.template\` \`databases.args\` — the db template's \`\$(name=)\` macro is GUI-only with an empty default, so removing it is safe.

### mks937a/b: clarify int param descriptions (1c89503)
- The \`id\` / \`address\` parameters on \`mks937aGauge\`, \`mks937aGaugeEGU\`, \`mks937bGauge\`, \`mks937bGaugeEGU\`, and \`mks937b\` are all \`type: int\`, but their descriptions still read \"ID number as 2 digit string (e.g. 01)\" / \"Controller address (001 .. 253)\" — stale text from when the types were \`str\`.
- Rephrase to make clear the parameter is an int and the Jinja expressions (\`{{ '%02d' % id }}\`, \`{{ '%03d' % address }}\`) render it zero-padded when producing ioc.subst.

Paired with:
- \`ibek-support-dls\` MR: https://gitlab.diamond.ac.uk/controls/containers/utils/ibek-support-dls/-/merge_requests/15
- \`builder2ibek\` PR: https://github.com/epics-containers/builder2ibek/pull/97

## Test plan
- [x] \`builder2ibek\` full pytest with paired submodule commits (39 passed)