### PR TITLE
Correct db path for motorUtil entity in motor ibek-support

### DIFF
--- a/motor/motor.ibek.support.yaml
+++ b/motor/motor.ibek.support.yaml
@@ -17,7 +17,7 @@ entity_models:
           motorUtilInit("{{ P }}")
 
     databases:
-      - file: $(MOTOR)/db/motorUtil.template
+      - file: $(MOTOR)/db/motorUtil.db
         args:
           P:
 


### PR DESCRIPTION
Corrects path to `motorUtil.db` from `motorUtil.template`. See [motorApp/Db](https://github.com/epics-modules/motor/tree/R7-3-1/motorApp/Db)