### PR TITLE
Replaced 'parent' with 'Include'

### DIFF
--- a/ADCore/NDPluginBase.pvi.device.yaml
+++ b/ADCore/NDPluginBase.pvi.device.yaml
@@ -1,5 +1,4 @@
 label: NDPluginBase
-parent: NDArrayBase
 children:
 
 - type: Group
@@ -184,3 +183,6 @@ children:
     read_pv: $(P)$(R)DisorderedArrays_RBV
     read_widget:
       type: TextRead
+
+- type: Include
+  file_name: NDArrayBase

--- a/ADCore/NDProcess.pvi.device.yaml
+++ b/ADCore/NDProcess.pvi.device.yaml
@@ -1,5 +1,4 @@
 label: NDProcess
-parent: NDPluginBase
 children:
 
 - type: Group
@@ -354,3 +353,6 @@ children:
     read_pv: $(P)$(R)DataTypeOut_RBV
     read_widget:
       type: TextRead
+
+- type: Include
+  file_name: NDPluginBase

--- a/ADCore/NDPvxs.pvi.device.yaml
+++ b/ADCore/NDPvxs.pvi.device.yaml
@@ -1,5 +1,4 @@
 label: NDPvxs
-parent: NDPluginBase
 children:
 
 - type: Group
@@ -15,3 +14,6 @@ children:
     read_widget:
       type: TextRead
       format: string
+
+- type: Include
+  file_name: NDPluginBase

--- a/ADCore/NDStdArrays.pvi.device.yaml
+++ b/ADCore/NDStdArrays.pvi.device.yaml
@@ -1,5 +1,4 @@
 label: NDStdArrays
-parent: NDPluginBase
 children:
 
 - type: Group
@@ -15,3 +14,6 @@ children:
     read_pv: $(P)$(R)ArrayData
     read_widget:
       type: TextRead
+
+- type: Include
+  file_name: NDPluginBase


### PR DESCRIPTION
Replaced `parent` with `Include` for some pvi yaml files