### PR TITLE
Fix positioner runtime errors

### DIFF
--- a/positioner/positioner.ibek.support.yaml
+++ b/positioner/positioner.ibek.support.yaml
@@ -112,6 +112,11 @@ entity_models:
         description: |-
           Positioner value for position 16
         default: 0
+      pos:
+        type: str
+        description: |-
+          Positioner letter (A..H)
+        default: A
 
     databases:
       - file: $(POSITIONER)/db/motorpositioner.template
@@ -386,6 +391,11 @@ entity_models:
         description: |-
           Positioner value for position 16
         default: 0
+      pos:
+        type: str
+        description: |-
+          Positioner letter (A..H)
+        default: A
 
     databases:
       - file: $(POSITIONER)/db/positioner.template
@@ -417,3 +427,4 @@ entity_models:
           VALN:
           VALO:
           VALP:
+          pos:


### PR DESCRIPTION
Added missing pos field which was the cause of runtime errors on ioc startup preventing the positioner ioc from working.

Tested and working on BL15I-MO-PPMAC-42.

Note that the motor name should not include P when compared to the bulider ioc see https://github.com/epics-containers/builder2ibek/issues/103