### PR TITLE
add pvi generation for aduvc screen

### DIFF
--- a/ADUVC/ADUVC.ibek.support.yaml
+++ b/ADUVC/ADUVC.ibek.support.yaml
@@ -31,7 +31,7 @@ entity_models:
         default: ""
 
       TIMEOUT:
-        type: int
+        type: int 
         description: Timeout
         default: 1
 
@@ -76,3 +76,11 @@ entity_models:
           NELEMENTS: "6000000"
           TIMEOUT: "{{TIMEOUT}}"
           ADDR: "{{ADDR}}"
+
+    pvi:
+      yaml_path: ADUVC.pvi.device.yaml
+      ui_macros:
+        P:
+        R:
+      pv: true
+      pv_prefix: $(P)$(R)

--- a/ADUVC/ADUVC.ibek.support.yaml
+++ b/ADUVC/ADUVC.ibek.support.yaml
@@ -31,7 +31,7 @@ entity_models:
         default: ""
 
       TIMEOUT:
-        type: int 
+        type: int
         description: Timeout
         default: 1
 


### PR DESCRIPTION
to generate ADUVC screen. See it deployed on ViSR:

https://daedalus-test.diamond.ac.uk/synoptic/b01-1/B01-1%20Synoptic/Synchrotron%20Alignment%20Camera/DRV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced ADUVC module configuration to support parameter exposure with configurable naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->