### PR TITLE
Huy new adaravis pvi and db file names

### DIFF
--- a/ADAravis/ADAravis.ibek.support.yaml
+++ b/ADAravis/ADAravis.ibek.support.yaml
@@ -196,8 +196,8 @@ entity_models:
     databases:
       # If CLASS=='AutoADGenICam', the template will be named similarly to
       # pvi device yaml. If not, the name is CLASS.template, which is intended
-      # to be a pre-created template files, ie, in this case the format is 
-      # different from that of pvi device yaml
+      # to reference predefine template file (so the template name's format is 
+      # different from that of pvi device yaml)
       - file: "{{ 'ADAravis-' ~ camera.P if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.template"
         args:
           P: "{{ camera.P }}"

--- a/ADAravis/ADAravis.ibek.support.yaml
+++ b/ADAravis/ADAravis.ibek.support.yaml
@@ -196,8 +196,8 @@ entity_models:
     databases:
       # If CLASS=='AutoADGenICam', the template will be named similarly to
       # pvi device yaml. If not, the name is CLASS.template, which is intended
-      # to reference predefine template file (so the template name's format is 
-      # different from that of pvi device yaml)
+      # to reference predefine template file (this means the template name's format is 
+      # different from that of pvi device yaml).
       - file: "{{ 'ADAravis-' ~ camera.P if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.template"
         args:
           P: "{{ camera.P }}"

--- a/ADAravis/ADAravis.ibek.support.yaml
+++ b/ADAravis/ADAravis.ibek.support.yaml
@@ -182,7 +182,11 @@ entity_models:
         description: the aravisCamera object to create settings for
 
     pvi:
-      yaml_path: "{{ 'ADAravis-' ~ camera.P if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.pvi.device.yaml"
+      # Following discussion with Tom Kane et al on Slack on 3/7/26,
+      # pvi device yaml will be named ADAravis-{{ P }}.pvi.device.yaml
+      # whether CLASS=='AutoADGenICam' or not. This keeps things simple
+      # for techui-support.
+      yaml_path: "{{ 'ADAravis-' ~ camera.P }}.pvi.device.yaml"
       ui_macros:
         P: "{{ camera.P }}"
         R: "{{ camera.R }}"
@@ -190,6 +194,10 @@ entity_models:
       pv_prefix: "{{ camera.P }}{{ camera.R }}"
 
     databases:
+      # If CLASS=='AutoADGenICam', the template will be named similarly to
+      # pvi device yaml. If not, the name is CLASS.template, which is intended
+      # to be a pre-created template files, ie, in this case the format is 
+      # different from that of pvi device yaml
       - file: "{{ 'ADAravis-' ~ camera.P if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.template"
         args:
           P: "{{ camera.P }}"

--- a/ADAravis/ADAravis.ibek.support.yaml
+++ b/ADAravis/ADAravis.ibek.support.yaml
@@ -182,7 +182,7 @@ entity_models:
         description: the aravisCamera object to create settings for
 
     pvi:
-      yaml_path: "{{ 'auto-' ~ camera.ID if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.pvi.device.yaml"
+      yaml_path: "{{ 'ADAravis-' ~ camera.P if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.pvi.device.yaml"
       ui_macros:
         P: "{{ camera.P }}"
         R: "{{ camera.R }}"
@@ -190,7 +190,7 @@ entity_models:
       pv_prefix: "{{ camera.P }}{{ camera.R }}"
 
     databases:
-      - file: "{{ 'auto-' ~ camera.ID if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.template"
+      - file: "{{ 'ADAravis-' ~ camera.P if camera.CLASS=='AutoADGenICam' else camera.CLASS }}.template"
         args:
           P: "{{ camera.P }}"
           R: "{{ camera.R }}"


### PR DESCRIPTION
Following discussion with Tom Kane et al on Slack on 3/7/26, pvi device yaml will be named ADAravis-{{ P }}.pvi.device.yaml whether CLASS=='AutoADGenICam' or not. This keeps things simple for techui-support.

For the DB, if CLASS=='AutoADGenICam', the template will be named similarly to pvi device yaml. If not, the name is CLASS.template, which is intended to reference predefine template file (this means the template name's format is different from that of pvi device yaml).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated device file naming to use a more consistent camera-based pattern.
  * Improved template selection so automatically generated configurations now choose the appropriate file name based on camera type, while keeping existing prefix behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->