### PR TITLE
Fix autosave soft limits 

### DIFF
--- a/pmac/basic_asyn_motor_positions.req
+++ b/pmac/basic_asyn_motor_positions.req
@@ -1,2 +1,8 @@
+# NOTE: .DHLM/.DLLM are restored at pass 0 (positions) rather than pass 1
+# (settings), so the soft limits reach the brick before record init. This
+# deviates from basic_asyn_motor.template's `#% autosave 1` hint, so
+# `builder2ibek autosave` will revert it -- reapply after any regeneration.
+$(P)$(M).DHLM
+$(P)$(M).DLLM
 $(P)$(M).DVAL
 $(P)$(M).OFF

--- a/pmac/basic_asyn_motor_settings.req
+++ b/pmac/basic_asyn_motor_settings.req
@@ -1,13 +1,15 @@
+# NOTE: .DHLM/.DLLM are restored at pass 0 (positions) rather than pass 1
+# (settings), so the soft limits reach the brick before record init. This
+# deviates from basic_asyn_motor.template's `#% autosave 1` hint, so
+# `builder2ibek autosave` will revert it -- reapply after any regeneration.
 $(P)$(M).ACCL
 $(P)$(M).ADEL
 $(P)$(M).BACC
 $(P)$(M).BDST
 $(P)$(M).BVEL
-$(P)$(M).DHLM
 $(P)$(M).DIR
 $(P)$(M).DISA
 $(P)$(M).DISP
-$(P)$(M).DLLM
 $(P)$(M).DLY
 $(P)$(M).EGU
 $(P)$(M).FOFF


### PR DESCRIPTION
Soft limits are currently only partially restored, only DHLM and DLLM, and not sent to the brick on ioc startup. This means that soft limit values indicated by corresponding PVs and the limit values being used by the brick do not always match.  For details see: https://github.com/DiamondLightSource/pmac/pull/164

This fix adds LLM and HLM to autosave so that all soft limits values are restored from autosave values and autosaved soft limit values are restored before ioc record initialisation (motor positions req file) so they are sent to the brick on ioc startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high and low motor limit parameters to basic motor position settings.

* **Bug Fixes**
  * Updated motor setting declarations for clearer error-limit configuration.
  * Removed duplicate high and low limit settings while retaining the motor movement deadband setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->