### PR TITLE
terminalserver: honour NCHANS instead of hardcoding channel counts

### DIFF
--- a/terminalserver/terminalserver.ibek.support.yaml
+++ b/terminalserver/terminalserver.ibek.support.yaml
@@ -70,22 +70,17 @@ entity_models:
           Number of channels
 
     sub_entities:
-      - { type: terminalServer.MoxaChannel, CHAN: 1, name: "{{name}}_1", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 2, name: "{{name}}_2", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 3, name: "{{name}}_3", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 4, name: "{{name}}_4", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 5, name: "{{name}}_5", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 6, name: "{{name}}_6", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 7, name: "{{name}}_7", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 8, name: "{{name}}_8", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 9, name: "{{name}}_9", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 10, name: "{{name}}_10", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 11, name: "{{name}}_11", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 12, name: "{{name}}_12", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 13, name: "{{name}}_13", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 14, name: "{{name}}_14", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 15, name: "{{name}}_15", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 16, name: "{{name}}_16", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
+      # one channel per NCHANS; see the module's NCHANS parameter
+      - type: ibek.repeat
+        variable: chan
+        values: "{{ range(1, NCHANS + 1) | list }}"
+        entity:
+          type: terminalServer.MoxaChannel
+          name: "{{ name }}_{{ chan }}"
+          P: "{{ P }}"
+          R: "{{ R }}"
+          CHAN: "{{ chan }}"
+          HOST: "{{ HOST }}"
 
     databases:
       - file: $(TERMINALSERVER)/db/TerminalServer16.template
@@ -129,38 +124,17 @@ entity_models:
           Number of channels
 
     sub_entities:
-      - { type: terminalServer.MoxaChannel, CHAN: 1, name: "{{name}}_1", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 2, name: "{{name}}_2", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 3, name: "{{name}}_3", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 4, name: "{{name}}_4", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 5, name: "{{name}}_5", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 6, name: "{{name}}_6", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 7, name: "{{name}}_7", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 8, name: "{{name}}_8", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 9, name: "{{name}}_9", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 10, name: "{{name}}_10", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 11, name: "{{name}}_11", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 12, name: "{{name}}_12", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 13, name: "{{name}}_13", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 14, name: "{{name}}_14", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 15, name: "{{name}}_15", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 16, name: "{{name}}_16", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 17, name: "{{name}}_17", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 18, name: "{{name}}_18", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 19, name: "{{name}}_19", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 20, name: "{{name}}_20", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 21, name: "{{name}}_21", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 22, name: "{{name}}_22", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 23, name: "{{name}}_23", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 24, name: "{{name}}_24", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 25, name: "{{name}}_25", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 26, name: "{{name}}_26", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 27, name: "{{name}}_27", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 28, name: "{{name}}_28", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 29, name: "{{name}}_29", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 30, name: "{{name}}_30", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 31, name: "{{name}}_31", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.MoxaChannel, CHAN: 32, name: "{{name}}_32", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
+      # one channel per NCHANS; see the module's NCHANS parameter
+      - type: ibek.repeat
+        variable: chan
+        values: "{{ range(1, NCHANS + 1) | list }}"
+        entity:
+          type: terminalServer.MoxaChannel
+          name: "{{ name }}_{{ chan }}"
+          P: "{{ P }}"
+          R: "{{ R }}"
+          CHAN: "{{ chan }}"
+          HOST: "{{ HOST }}"
 
     databases:
       - file: $(TERMINALSERVER)/db/TerminalServer32.template
@@ -238,22 +212,17 @@ entity_models:
           Number of channels
 
     sub_entities:
-      - { type: terminalServer.AcsChannel, CHAN: 1, name: "{{name}}_1", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 2, name: "{{name}}_2", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 3, name: "{{name}}_3", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 4, name: "{{name}}_4", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 5, name: "{{name}}_5", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 6, name: "{{name}}_6", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 7, name: "{{name}}_7", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 8, name: "{{name}}_8", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 9, name: "{{name}}_9", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 10, name: "{{name}}_10", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 11, name: "{{name}}_11", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 12, name: "{{name}}_12", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 13, name: "{{name}}_13", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 14, name: "{{name}}_14", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 15, name: "{{name}}_15", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 16, name: "{{name}}_16", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
+      # one channel per NCHANS; see the module's NCHANS parameter
+      - type: ibek.repeat
+        variable: chan
+        values: "{{ range(1, NCHANS + 1) | list }}"
+        entity:
+          type: terminalServer.AcsChannel
+          name: "{{ name }}_{{ chan }}"
+          P: "{{ P }}"
+          R: "{{ R }}"
+          CHAN: "{{ chan }}"
+          HOST: "{{ HOST }}"
 
     databases:
       - file: $(TERMINALSERVER)/db/TerminalServer16.template
@@ -297,38 +266,17 @@ entity_models:
           Number of channels
 
     sub_entities:
-      - { type: terminalServer.AcsChannel, CHAN: 1, name: "{{name}}_1", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 2, name: "{{name}}_2", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 3, name: "{{name}}_3", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 4, name: "{{name}}_4", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 5, name: "{{name}}_5", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 6, name: "{{name}}_6", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 7, name: "{{name}}_7", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 8, name: "{{name}}_8", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 9, name: "{{name}}_9", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 10, name: "{{name}}_10", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 11, name: "{{name}}_11", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 12, name: "{{name}}_12", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 13, name: "{{name}}_13", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 14, name: "{{name}}_14", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 15, name: "{{name}}_15", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 16, name: "{{name}}_16", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 17, name: "{{name}}_17", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 18, name: "{{name}}_18", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 19, name: "{{name}}_19", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 20, name: "{{name}}_20", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 21, name: "{{name}}_21", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 22, name: "{{name}}_22", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 23, name: "{{name}}_23", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 24, name: "{{name}}_24", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 25, name: "{{name}}_25", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 26, name: "{{name}}_26", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 27, name: "{{name}}_27", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 28, name: "{{name}}_28", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 29, name: "{{name}}_29", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 30, name: "{{name}}_30", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 31, name: "{{name}}_31", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
-      - { type: terminalServer.AcsChannel, CHAN: 32, name: "{{name}}_32", P: "{{P}}", R: "{{R}}", HOST: "{{HOST}}" }
+      # one channel per NCHANS; see the module's NCHANS parameter
+      - type: ibek.repeat
+        variable: chan
+        values: "{{ range(1, NCHANS + 1) | list }}"
+        entity:
+          type: terminalServer.AcsChannel
+          name: "{{ name }}_{{ chan }}"
+          P: "{{ P }}"
+          R: "{{ R }}"
+          CHAN: "{{ chan }}"
+          HOST: "{{ HOST }}"
 
     databases:
       - file: $(TERMINALSERVER)/db/TerminalServer32.template


### PR DESCRIPTION
Follow-up spotted while resolving a duplicate `terminalServer` module (see below).

## The bug

`Moxa16`, `Moxa32`, `Acs16` and `Acs32` each declare an `NCHANS` parameter — and then ignore it, hardcoding exactly 16 or 32 channel `sub_entities`. A terminal server configured with `NCHANS: 8` still gets 16 `MoxaChannel` instances, so 8 of them poll ports that do not exist.

## The fix

Replace the hardcoded lists with `ibek.repeat` over `range(1, NCHANS + 1)`:

```yaml
    sub_entities:
      # one channel per NCHANS; see the module's NCHANS parameter
      - type: ibek.repeat
        variable: chan
        values: "{{ range(1, NCHANS + 1) | list }}"
        entity:
          type: terminalServer.MoxaChannel
          name: "{{ name }}_{{ chan }}"
          P: "{{ P }}"
          R: "{{ R }}"
          CHAN: "{{ chan }}"
          HOST: "{{ HOST }}"
```

This is the "iterable sub-entities" the module's own TODO comment asks for, and it removes 96 lines of hand-written repetition. Crucially it keeps the channels as `sub_entities`, so they continue to land in `ioc.subst` rather than moving to `dbLoadRecords` in `st.cmd` — which matches the stated intent in that TODO of having the IOC's db match the auto-converted traditional IOC.

## Verification

Generated `ioc.subst` and `st.cmd` with ibek 3.3.5, before vs after:

| entity | NCHANS | channels | vs previous output |
|---|---|---|---|
| Moxa16 | 16 | 16 | **byte-identical** |
| Moxa32 | 32 | 32 | **byte-identical** |
| Acs16 | 16 | 16 | **byte-identical** |
| Acs32 | 32 | 32 | **byte-identical** |
| Moxa16 | 8 | 8 | was 16 |
| Moxa32 | 24 | 24 | was 32 |

Every `NCHANS` value in use today equals the previously hardcoded count — i04 `bl04i-cs-ioc-01` Moxa32=32, i11 `bl11i-cs-ioc-12` Moxa16=16, `ibek-support-dls/SR-VA` Moxa16=16 — so **no existing IOC's generated output changes**.

## Context

`module: terminalServer` was declared twice: here and in `ibek-support-dls/terminalServer` (folder names differ only in case, which is how it evaded the no-duplicate-modules rule). The DLS copy defined only Moxa16/Moxa32 — no ACS entities, which `builder2ibek`'s converter emits — but it *did* honour `NCHANS` via a Jinja `dbLoadRecords` loop. The DLS copy is being removed as the strict subset; this PR ports over the one capability it had that this module lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel configuration now automatically generates the correct number of channels for Moxa16, Moxa32, Acs16, and Acs32 devices.
  * Preserved channel names and parameters across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->