### PR TITLE
digitelMpc: bump 6-21 -> 6-23ec1

### DIFF
--- a/digitelMpc/digitelMpc.install.yml
+++ b/digitelMpc/digitelMpc.install.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../_scripts/support_install_variables.json
 
 module: digitelMPC
-version: 6-21
+version: 6-23ec1
 dbds:
   - digitelMpc.dbd
 libs:


### PR DESCRIPTION
Bumps digitelMpc from `6-21` to `6-23ec1` (10 commits ahead):

- self-contained MPS interlock word display
- confirmation prompt before the reset command (ACS-401), with the device
  macro added to the reset screen title
- README added, irrelevant DEVHISTORY.TXT removed

The single commit `6-21` has that `6-23ec1` does not is *"sanitise for external
consumption"*. The files it touched — `configure/RELEASE.local` in particular —
are present in **both** tags, so nothing regresses.

## Provenance

Extracted from the stale `ioc-dlslinuxvac` branch (Sep 2025), which is being
retired. That branch bundled a second change — moving FINS off the
`rtems-epics-7` branch onto tag `3-12ec1` — which is **deliberately excluded**.
The two have diverged: `rtems-epics-7` is 3 commits ahead with exactly the RTEMS
compile fixes (`changes to compile for rtems`, `dont redefine errno in RTEMS6`)
that the hybrid RTEMS vacuum IOCs depend on. FINS needs a tag that merges both
lines before it can move; that is left as separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)