### PR TITLE
Add positioner number to multipositioner parameters

### DIFF
--- a/positioner/positioner.ibek.support.yaml
+++ b/positioner/positioner.ibek.support.yaml
@@ -138,6 +138,10 @@ entity_models:
         type: str
         description: |-
           Device suffix
+      PS:
+        type: str
+        description: |-
+          Positioner number
       DESC:
         type: str
         description: |-


### PR DESCRIPTION
For backwards compatibility with the old `builder.py` logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public positioner number parameter to multipositioner entities, making each positioner’s identifier available for display and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->