### PR TITLE
Add default to PS parameter of multipositioner

### DIFF
--- a/positioner/positioner.ibek.support.yaml
+++ b/positioner/positioner.ibek.support.yaml
@@ -141,7 +141,8 @@ entity_models:
       PS:
         type: str
         description: |-
-          Positioner number
+          Positioner number suffix
+        default: :P1
       DESC:
         type: str
         description: |-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the positioner parameter description to indicate it is a suffix.
  * Added `:P1` as the default positioner suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->