### PR TITLE
Remove default of PS macro for multipositioner

### DIFF
--- a/positioner/positioner.ibek.support.yaml
+++ b/positioner/positioner.ibek.support.yaml
@@ -142,7 +142,7 @@ entity_models:
         type: str
         description: |-
           Positioner number suffix
-        default: :P1
+        default: ""
       DESC:
         type: str
         description: |-


### PR DESCRIPTION
This logic is handled in the builder2ibek logic, and will strip :P1 if that is there, which we want to keep