### PR TITLE
Refuse to build a support module whose install.yml names no module

### DIFF
--- a/_ansible/roles/find/tasks/main.yml
+++ b/_ansible/roles/find/tasks/main.yml
@@ -39,3 +39,23 @@
     - name: Read in the support module vars for {{ module }}
       ansible.builtin.include_vars:
         file: "{{ ansible_root }}/vars/.tmp.install.yml"
+
+    # Without this, an install.yml that names no module leaves module empty,
+    # so local_path becomes {{ support_folder }} itself. The clone is then
+    # skipped - that folder exists - and the release tasks append
+    # '-include $(TOP)/configure/RELEASE.local' to the GLOBAL
+    # configure/RELEASE. Every module built afterwards symlinks its own
+    # RELEASE.local to that file, so make includes it recursively until it
+    # runs out of file descriptors: 'configure/RELEASE.local:4: *** Too many
+    # open files'. In a build of many modules one bad install.yml therefore
+    # breaks every module behind it, and the error names neither the culprit
+    # nor the real fault.
+    - name: Check that the install.yml for {{ module }} names a module and a version
+      ansible.builtin.assert:
+        that:
+          - module | default("", true) | string | length > 0
+          - version | default("", true) | string | length > 0
+        fail_msg: >-
+          {{ ibek_support_folder }} must set both 'module' and 'version' in its
+          install.yml
+        quiet: true


### PR DESCRIPTION
## The failure

An `install.yml` with no `module` key leaves the variable empty, so `local_path` becomes `/epics/support` itself. From there:

1. the clone is skipped, because "Check if the repo has already been cloned" finds that directory exists;
2. `release.yml` appends `-include $(TOP)/configure/RELEASE.local` to what is now the **global** `configure/RELEASE`, and links `/epics/support/configure/RELEASE.local` to it;
3. every module built afterwards symlinks its own `RELEASE.local` to that same global file, which now includes `$(TOP)/configure/RELEASE.local` — itself, via each module's TOP.

Make then recurses until it runs out of file descriptors:

```
configure/RELEASE.local:4: *** Too many open files.  Stop.
```

The give-away in the log is the clone line for the culprit:

```
TASK [support : Clone https://github.com/epics-modules/ vers None to /epics/support/]
```

## Why it is worth guarding

In a container that builds modules in sequence, one stub `install.yml` breaks **every module behind it**, and the error names neither the culprit nor the real fault — it points at `RELEASE.local`, which is only a symlink to the damage.

Found in `ibek-support-dls`, where a build of all 107 modules failed 107 times from a single bad file at position 3. Diagnosing that from the build log alone took a while; the assert would have said it in one line.

## The change

An `assert` in the `find` role, immediately after the module's vars are read, naming the folder at fault. All 41 `install.yml` files in this repo already satisfy it, so nothing here changes behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure support-module installation files include both module and version values.
  * Improved error messages to identify the affected support folder when installation data is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->