### PR TITLE
Include RELEASE.local last, so the container's paths actually win

### DIFF
--- a/_ansible/RELEASE.global
+++ b/_ansible/RELEASE.global
@@ -9,4 +9,24 @@ SUPPORT=/epics/support
 EPICS_BASE=/epics/epics-base
 PVXS=/epics/support/pvxs
 
+# DLS modules define WORK, naming the /dls_sw work area that unreleased
+# support modules are built in. Nothing in a container can reach it, but the
+# value still has to be consistent: convertRelease.pl checkRelease compares
+# every macro across a module and the modules it references, so two modules
+# defining WORK for different EPICS versions - which is common, these are the
+# work areas of whichever release the module was cut against - fail the build
+# of the module that references them:
+#
+#   Definition of WORK conflicts with OXCS700ASYN support.
+#   Here: WORK = /dls_sw/work/R7.0.7/support
+#   OXCS700ASYN: WORK = /dls_sw/work/R3.14.12.7/support
+#
+# Defining it here gives every module the same value, since RELEASE.local is
+# included last. The path deliberately does not exist: checkRelease compares
+# values without requiring them to resolve, and of 92 DLS module source trees
+# checked, none reads $(WORK) during its own build - the only references are
+# in example IOC RELEASE files and in shipped configure/RELEASE.local files,
+# which are replaced by the symlink to this file.
+WORK=/epics/work-area-not-available-in-container
+
 # Additional Support Modules for individual IOCs will be added below this line

--- a/_ansible/group_vars/all.yml
+++ b/_ansible/group_vars/all.yml
@@ -30,6 +30,9 @@ config_linux_target: configure/CONFIG_SITE.Common.linux-x86_64
 
 # quick access to the target architecture
 target_arch: "{{ lookup('ansible.builtin.env', 'EPICS_TARGET_ARCH') }}"
+# the arch this is building ON, which names the arch specific RELEASE and
+# CONFIG_SITE files that configure/CONFIG reads after the plain ones
+host_arch: "{{ lookup('ansible.builtin.env', 'EPICS_HOST_ARCH') }}"
 is_rtems: "{{ 'RTEMS' in target_arch }}"
 is_linux: "{{ 'linux' in target_arch }}"
 

--- a/_ansible/roles/support/tasks/release.yml
+++ b/_ansible/roles/support/tasks/release.yml
@@ -8,15 +8,39 @@
         mode: "0644"
         force: false
 
-    - name: Ensure that configure/RELEASE includes RELEASE.local for {{ module }}
-      ansible.builtin.lineinfile:
-        path: "{{ local_path }}/configure/RELEASE"
-        regexp: "include.*TOP./configure/RELEASE.local"
-        line: "-include $(TOP)/configure/RELEASE.local"
+    # RELEASE.local carries the container's paths, so it only wins if it is
+    # included LAST. Two things stop that happening on their own:
+    #
+    #  - a module may already include RELEASE.local partway through its own
+    #    configure/RELEASE, and define EPICS_BASE below that point - upstream
+    #    files often say "EPICS_BASE usually appears last so other apps can
+    #    override stuff". A lineinfile keyed on the include would match that
+    #    early line and edit it in place, leaving the DLS EPICS_BASE to win.
+    #    blockinfile with its own marker always appends at the end instead.
+    #
+    #  - configure/CONFIG reads the arch specific RELEASE files AFTER
+    #    configure/RELEASE, so a module shipping RELEASE.<host arch>.Common
+    #    with its own SUPPORT and EPICS_BASE overrides everything in RELEASE,
+    #    RELEASE.local included. Those files get the same treatment.
+    #
+    # RELEASE.local itself is deliberately absent from the list below: it is a
+    # symlink to the global configure/RELEASE, so appending to it would make
+    # that file include itself for every module.
+    - name: Ensure RELEASE.local is included last for {{ module }}
+      ansible.builtin.blockinfile:
+        path: "{{ local_path }}/configure/{{ item }}"
+        marker: "# {mark} ibek-support - the container's paths must win"
+        block: -include $(TOP)/configure/RELEASE.local
         insertafter: EOF
-
-        create: true
+        create: "{{ (item == 'RELEASE') | bool }}"
         mode: "0644"
+      when: item == "RELEASE" or
+            (local_path ~ "/configure/" ~ item) is exists
+      loop:
+        - RELEASE
+        - RELEASE.{{ host_arch }}.Common
+        - RELEASE.Common.{{ target_arch }}
+        - RELEASE.{{ host_arch }}.{{ target_arch }}
 
     - name: Insert the global RELEASE as link to RELEASE.local for {{ module }}
       ansible.builtin.file:


### PR DESCRIPTION
`RELEASE.local` carries the container's `EPICS_BASE` and `SUPPORT`, but it only overrides a module's own values if it is included **after** them. Two things stopped that.

## 1. The module already includes RELEASE.local, too early

The task was a `lineinfile` keyed on the include itself:

```yaml
regexp: "include.*TOP./configure/RELEASE.local"
line: "-include $(TOP)/configure/RELEASE.local"
insertafter: EOF
```

When a module already has that line, lineinfile matches it and edits **in place** — `insertafter: EOF` never applies. DLS modules commonly do exactly this, then define `EPICS_BASE` further down. `mrfioc2` 2-2-0dls6:

```make
# The definitions shown below can also be placed in an untracked RELEASE.local
-include $(TOP)/../RELEASE.local
-include $(TOP)/configure/RELEASE.local      <-- the patch lands here

DEVLIB2=$(SUPPORT)/devlib2/2-9dls1

# EPICS_BASE usually appears last so other apps can override stuff:
EPICS_BASE=/dls_sw/epics/R3.14.12.7/base     <-- so this wins
```

and the build dies with:

```
configure/RULES_TOP:2: /dls_sw/epics/R3.14.12.7/base/configure/RULES_TOP: No such file or directory
make: *** No rule to make target '/dls_sw/epics/R3.14.12.7/base/configure/RULES_TOP'.  Stop.
```

The ansible log gives it away by reporting that task as `ok` rather than `changed`.

`blockinfile` with its own marker always appends at the end, whatever the file already contains, and stays idempotent across rebuilds.

## 2. Arch-specific RELEASE files are read after configure/RELEASE

`configure/CONFIG` includes `RELEASE.$(EPICS_HOST_ARCH).Common`, `RELEASE.Common.$(T_A)` and `RELEASE.$(EPICS_HOST_ARCH).$(T_A)` *after* `configure/RELEASE`. A module shipping one of those with its own `SUPPORT`/`EPICS_BASE` therefore beats everything in `RELEASE`, `RELEASE.local` included — no ordering inside `RELEASE` can fix it. `BL21I` ships:

```make
SUPPORT=/dls_sw/prod/R3.14.12.7/support
WORK=/dls_sw/work/R3.14.12.7/support
EPICS_BASE=/dls_sw/epics/R3.14.12.7/base
```

Those files now get the same include appended, and being read last, the container's paths win.

`RELEASE.local` itself is deliberately absent from the loop: it is a symlink to the global `configure/RELEASE`, so appending to it would make that file include itself for every module.

Adds `host_arch` alongside the existing `target_arch` in group_vars, since these filenames are keyed on `EPICS_HOST_ARCH`.

## Provenance

Found while building all 107 modules of `ibek-support-dls` in one container — 7 failed for these two reasons. This repo's own CI builds every group in a container, so it exercises the change directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)